### PR TITLE
Update lambda region ec2 policy

### DIFF
--- a/lambda.tf
+++ b/lambda.tf
@@ -38,7 +38,12 @@ resource "aws_iam_role_policy" "plain_logging_health_lambda_policy" {
         "ec2:Describe*"
       ],
       "Effect": "Allow",
-      "Resource": "arn:aws:ec2:us-east-1:*:instance/*"
+      "Resource": "*"
+      "Condition": {
+        "StringEquals": {
+          "ec2:Region": "us-east-1"
+        }
+      }
     }
   ]
 }


### PR DESCRIPTION
The previous policy using...

```
{
  "Action": [
    "ec2:Describe*"
  ],
  "Effect": "Allow",
  "Resource": "arn:aws:ec2:us-east-1:*:instance/*"
}
```

was failing on `DescribeInstances` in staging cloudwatch.  This was also replicated in the aws policy simulator in sandbox.

This new format had access for `DescribeInstances` in sandbox (of course there were no results... but was at least authorised).

Hoping this change to the policy does the trick while remaining locked down to a region.
